### PR TITLE
deps: ichiyoAI v1.12.2 への強制アップデート

### DIFF
--- a/ichiyo-ai/compose.yml
+++ b/ichiyo-ai/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/approvers/ichiyo_ai:v1.12.1
+    image: ghcr.io/approvers/ichiyo_ai:v1.12.2
     env_file:
       - .env
     deploy:


### PR DESCRIPTION
現在 Containers2 で起動中の ichiyoAI v1.12.1 には以下の不具合が存在しています.

- 返信モードで5文字以上のコンテキストがエラーで送信できない

また [webpki](https://github.com/briansmith/webpki) にてSSL関連の脆弱性 https://github.com/advisories/GHSA-8qv2-5vq6-g2g7 が報告されており, ichiyoAI v1.12.2 ではこれらの修正パッチを含んでいます. ( https://github.com/approvers/ichiyoAI/pull/111 )

普段使いに影響が出るような不具合のため, @renovate の PR を待たず強制アップデートを行います.