### PR TITLE
Revert "deps: ichiyoAI v1.12.2 への強制アップデート (#28)"

### DIFF
--- a/ichiyo-ai/compose.yml
+++ b/ichiyo-ai/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/approvers/ichiyo_ai:v1.12.1
+    image: ghcr.io/approvers/ichiyo_ai:v1.11.1
     env_file:
       - .env
     deploy:

--- a/ichiyo-ai/compose.yml
+++ b/ichiyo-ai/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/approvers/ichiyo_ai:v1.12.2
+    image: ghcr.io/approvers/ichiyo_ai:v1.12.1
     env_file:
       - .env
     deploy:


### PR DESCRIPTION
ichiyoAI v1.12.2 はリプライモードが正常に動作しない問題が報告されているため (https://github.com/approvers/ichiyoAI/issues/116), c04954e796ef625f1164dcbdbb0ba83d6be7e2d0 のコミットを revert した上で現行バージョン (v1) の中で安定している [v1.11.1](https://github.com/approvers/ichiyoAI/releases/tag/ichiyo_ai-v1.11.1) にロールバックします.

This reverts commit c04954e796ef625f1164dcbdbb0ba83d6be7e2d0.