### PR TITLE
deps: ichiyoAI v1.15.0 へのアップデート

### DIFF
--- a/ichiyo-ai/compose.yml
+++ b/ichiyo-ai/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/approvers/ichiyo_ai:v1.14.0
+    image: ghcr.io/approvers/ichiyo_ai:v1.15.0
     env_file:
       - .env
     deploy:


### PR DESCRIPTION
v1.14.0 のままでは動かないので v1.15.0 へアップデートします.